### PR TITLE
Update /ping response message in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 	r := gin.Default()
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(200, gin.H{
-			"message": "pong from private service auto deployed",
+			"message": "pong from private service with preview",
 		})
 	})
 	r.GET("/test", func(c *gin.Context) {


### PR DESCRIPTION
The message within the /ping endpoint response has been updated. It was previously set to "pong from private service auto deployed" but has now been changed to "pong from private service with preview" for clarity and to match new functionality.